### PR TITLE
README: Link to pinglamb repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/changelog-rb.
+Bug reports and pull requests are welcome on GitHub at https://github.com/pinglamb/changelog-rb.
 
 ## License
 


### PR DESCRIPTION
This PR fixes a boilerplate link to the real one.